### PR TITLE
Remove map blockers, parent spawnpoints, detect map end

### DIFF
--- a/gamemode/init.lua
+++ b/gamemode/init.lua
@@ -34,6 +34,7 @@ function GM:FixMap()
 	self:TryParentSpawnpoints()
 end
 
+GM.ServerSettings = GM.ServerSettings or {}
 GM.CSSSettings = {
 	sv_accelerate = 10,
 	sv_airaccelerate = 800,
@@ -43,9 +44,20 @@ GM.CSSSettings = {
 
 function GM:InitPostEntity()
 	for key, value in pairs(self.CSSSettings) do
+		-- Getting it as a string since it's safe for any datatype we may add to CSSSettings
+		local oldValue = GetConVar(key):GetString()
+		self.ServerSettings[key] = oldValue
+
 		game.ConsoleCommand(key .. " " .. value .. "\n")
 	end
 	self:FixMap()
+end
+
+function GM:ShutDown()
+	-- Reset the convars
+	for key, value in pairs(self.ServerSettings) do
+		game.ConsoleCommand(key .. " " .. value .. "\n")
+	end
 end
 
 function GM:PostCleanupMap()

--- a/gamemode/init.lua
+++ b/gamemode/init.lua
@@ -27,8 +27,11 @@ include("mapfixes/entities.lua")
 include("mapfixes/triggers.lua")
 
 function GM:FixMap()
+	self:RemoveMapBlockers()
 	self:ReplaceTriggerOnces()
+	self:ModifyHealTriggers()
 	self:MakeExplosionsRepeatable()
+	self:TryParentSpawnpoints()
 end
 
 GM.CSSSettings = {
@@ -109,9 +112,18 @@ function GM:EntityTakeDamage(ply, dmginfo)
 		return
 	end
 
+	self:CheckMapEnd(ply, dmginfo)
+
 	if dmginfo:IsExplosionDamage() and dmginfo:GetDamage() < 100 then
 		-- Player just missed a mine. Play the explosion noise but don't actually damage them
 		dmginfo:SetDamage(1)
 		ply:SetHealth(ply:Health() + 1)
 	end
+end
+
+--- Called when a player finishes the map
+--- @param ply GPlayer
+--- @param finishedAt number The time (recorded CurTime) at which the player crossed the finishline (This hook is called several moments after it)
+function GM:SlidePlayerFinished(ply, finishedAt)
+	PrintMessage(HUD_PRINTTALK, ply:Nick() .. " has finished!")
 end

--- a/gamemode/mapfixes/entities.lua
+++ b/gamemode/mapfixes/entities.lua
@@ -31,3 +31,46 @@ function GM:MakeExplosionsRepeatable()
 		ent:SetKeyValue("spawnflags", spawnflags)
 	end
 end
+
+function GM:RemoveMapBlockers()
+    for _, ent in pairs(ents.FindByClass("func_wall")) do
+        if(ent:GetName() == "gumpprotect")then
+            ent:Remove()
+        end
+    end
+
+    for _, ent in pairs(ents.FindByClass("func_brush")) do
+        local name = ent:GetName()
+
+        if(name == "gumblocker" or name == "noobweg")then
+            ent:Remove()
+        end
+    end
+end
+
+local function findMoveLinearBeneath(entity)
+    local tr = util.TraceLine({
+        start = entity:GetPos(),
+        endpos = entity:GetPos() - Vector(0, 0, 512),
+        filter = function( ent ) 
+            if ( ent:GetClass() == "func_movelinear" ) then
+                return true 
+            end 
+        end
+    })
+    
+    return tr.Entity
+end
+
+function GM:TryParentSpawnpoints()
+    for _, ent in pairs(ents.FindByClass("info_player_*")) do
+        local moveLinear = findMoveLinearBeneath(ent)
+
+        if(not IsValid(moveLinear))then
+            -- Don't waste time checking every spawnpoint, if the first one doesn't have a move linear beneath it, none do.
+            return
+        end
+
+        ent:SetParent(moveLinear)
+    end
+end

--- a/gamemode/mapfixes/entities.lua
+++ b/gamemode/mapfixes/entities.lua
@@ -46,6 +46,12 @@ function GM:RemoveMapBlockers()
             ent:Remove()
         end
     end
+
+    for _, ent in pairs(ents.FindByClass("trigger_hurt")) do
+        if(ent:GetName() == "gumkiller")then
+            ent:Remove()
+        end
+    end    
 end
 
 local function findMoveLinearBeneath(entity)

--- a/gamemode/mapfixes/triggers.lua
+++ b/gamemode/mapfixes/triggers.lua
@@ -1,44 +1,92 @@
 --[[
-	Slide - gamemode/mapfixes/triggers.lua
+Slide - gamemode/mapfixes/triggers.lua
 
-    Copyright 2017 Lex Robinson
+  Copyright 2017 Lex Robinson
 
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+      http://www.apache.org/licenses/LICENSE-2.0
 
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
 ]]--
 DEFINE_BASECLASS "gamemode_base"
 
+-- Interval between the -200 and 100 damage caused by trigger_hurt that informs us a player is at the end
+local END_CHECK_INTERVAL = 5
+
 local function replaceTrigger(ent)
-    if not ent.kvs then
-        ErrorNoHalt(string.format("Entity %s doesn't have its .kvs?", ent))
-        return
-    end
+  if not ent.kvs then
+    ErrorNoHalt(string.format("Entity %s doesn't have its .kvs?", ent))
+    return
+  end
 
-    -- Take the ent out of the game but don't remove it (Just in case [?])
-    ent:Fire("Disable")
+  -- Take the ent out of the game but don't remove it (Just in case [?])
+  ent:Fire("Disable")
 
-    local replacement = ents.Create('trigger_multiple')
-    for _, kv in ipairs(ent.kvs) do
-        if kv[1] ~= "classname" then
-            replacement:SetKeyValue(kv[1], kv[2])
-        end
+  local replacement = ents.Create('trigger_multiple')
+  for _, kv in ipairs(ent.kvs) do
+    if kv[1] ~= "classname" then
+      replacement:SetKeyValue(kv[1], kv[2])
     end
-    replacement:SetKeyValue("wait", 0)
-    replacement:Spawn()
-    replacement:Activate()
+  end
+  replacement:SetKeyValue("wait", 0)
+  replacement:Spawn()
+  replacement:Activate()
 end
 
 function GM:ReplaceTriggerOnces()
-    for _, ent in pairs(ents.FindByClass("trigger_once")) do
-        replaceTrigger(ent)
+  for _, ent in pairs(ents.FindByClass("trigger_once")) do
+    replaceTrigger(ent)
+  end
+end
+
+function GM:ModifyHealTriggers()
+  for _, trigger in ipairs(ents.FindByClass("trigger_hurt"))do
+    local damage = trigger:GetInternalVariable("damage")
+
+    if(damage < 0)then
+      trigger:SetKeyValue("damage", 0) 
+      trigger.HealAmount = math.abs(damage)
+    end 
+  end
+end
+
+function GM:CheckMapEnd(ply, dmginfo)
+  local attacker = dmginfo:GetAttacker()
+
+  if(not IsValid(attacker) or attacker:GetClass() ~= "trigger_hurt")then
+    print(attacker:GetClass())
+  
+    return
+  end
+
+  local damage = dmginfo:GetDamage()
+
+  if(damage ~= 0)then
+    if(attacker:GetInternalVariable("damage") ~= 100)then
+      return
     end
+
+    if(not ply._CheckIsFinishingMap or CurTime() - ply._CheckIsFinishingMap > END_CHECK_INTERVAL)then
+      print"too late since finish and hurt 100"
+      return
+    end
+
+    gamemode.Call("SlidePlayerFinished", ply, ply._CheckIsFinishingMap)
+    return
+  end
+
+  if(attacker.HealAmount ~= 200)then
+    return
+  end
+
+  ply:SetHealth(ply:Health() + attacker.HealAmount)
+  
+  ply._CheckIsFinishingMap = CurTime()
 end

--- a/gamemode/mapfixes/triggers.lua
+++ b/gamemode/mapfixes/triggers.lua
@@ -82,11 +82,11 @@ function GM:CheckMapEnd(ply, dmginfo)
     return
   end
 
+  ply:SetHealth(ply:Health() + attacker.HealAmount)
+  
   if(attacker.HealAmount ~= 200)then
     return
   end
 
-  ply:SetHealth(ply:Health() + attacker.HealAmount)
-  
   ply._CheckIsFinishingMap = CurTime()
 end

--- a/gamemode/mapfixes/triggers.lua
+++ b/gamemode/mapfixes/triggers.lua
@@ -1,19 +1,19 @@
 --[[
-Slide - gamemode/mapfixes/triggers.lua
+  Slide - gamemode/mapfixes/triggers.lua
 
-  Copyright 2017 Lex Robinson
+    Copyright 2017 Lex Robinson
 
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
 ]]--
 DEFINE_BASECLASS "gamemode_base"
 

--- a/gamemode/player_class/class_default.lua
+++ b/gamemode/player_class/class_default.lua
@@ -1,5 +1,5 @@
 --[[
-	Slide - gamemode/player_class/class_default.lua
+  Slide - gamemode/player_class/class_default.lua
 
     Copyright 2017 Lex Robinson
 
@@ -33,10 +33,10 @@ PLAYER.UnDuckSpeed       = 0.3       -- How fast to go from ducking, to not duck
 PLAYER.TeammateNoCollide = false
 
 function PLAYER:Loadout()
-	self.Player:RemoveAllAmmo()
+  self.Player:RemoveAllAmmo()
 
-	self.Player:GiveAmmo(256, "Pistol", true)
-	self.Player:Give("weapon_pistol")
+  self.Player:GiveAmmo(256, "Pistol", true)
+  self.Player:Give("weapon_pistol")
 end
 
 player_manager.RegisterClass("class_default", PLAYER, "player_default")

--- a/gamemode/rounds.lua
+++ b/gamemode/rounds.lua
@@ -1,0 +1,98 @@
+--- A round lasts from everyone spawning, until two players each of a different team have fought to the death or finished for over a minute (or 1 player if playing solo).
+
+--- The round we're playing at
+GM.Round = 1
+
+--- The amount of seconds between two players finishing and the round forcibly restarting
+GM.RoundEndGraceConVar = CreateConVar("slide_round_end_grace", 60, nil, "The time between two players of different teams finishing and the round ending.", 1)
+
+local STALLING_TIMER_NAME = "PreventRoundStalling"
+
+--- Make a player join a round
+--- @param ply GPlayer
+function GM:JoinRound(ply)
+  ply.RoundNumber = self.Round
+end
+
+--- Resets a round, cleaning up the map and allowing everybody to respawn
+function GM:ResetRound()
+  local newRoundNumber = self.Round + 1
+  PrintMessage(HUD_PRINTTALK, string.format("Starting new round (#%s)!", newRoundNumber))
+
+  timer.Remove(STALLING_TIMER_NAME)
+
+  -- Kill all other players silently
+  for _, ply in pairs(player.GetAll()) do
+    if(IsValid(ply) and ply:Alive())then
+      ply:KillSilent()
+    end
+  end
+
+  -- Do this in a timer, so we don't remove an invalid entity (like the skull that spawns on death, or ragdoll??)
+  -- Prevents a crash by doing game.CleanUpMap in a timer, unsure why
+  timer.Simple(0, function()
+    -- Quick workaround for issue @ https://github.com/Facepunch/garrysmod-issues/issues/3637
+    game.CleanUpMap(false, {"env_fire", "entityflame", "_firesmoke"})
+  
+    self.IsResetQueued = nil
+  
+    self.Round = newRoundNumber
+    
+    -- Respawn everyone
+    for _, teamID in ipairs(self.PlayingTeams) do
+      local players = team.GetPlayers(teamID)
+
+      for _, ply in ipairs(players) do
+        ply:Spawn()
+      end
+    end
+  end)
+end
+
+--- Checks if the round has ended by looking at all players
+function GM:CheckRoundEnd()
+  local numPlaying = 0
+
+  -- If of one team everyone has died, reset
+  for _, teamID in ipairs(self.PlayingTeams) do
+    local players = team.GetPlayers(teamID)
+    local liveCount = 0
+
+    numPlaying = numPlaying + #players
+
+    for _, ply in ipairs(players) do
+      if(ply:Alive())then
+        liveCount = liveCount + 1
+      end
+    end
+
+    -- If we got this far and all players of this team are dead, then reset
+    if(liveCount == 0 and #players > 0)then
+      PrintMessage(HUD_PRINTTALK, "All players of team " .. team.GetName(teamID) .. " have died!")
+      self:ResetRound()
+      return true
+    end
+  end
+
+  -- If playing solo, reset on death, finish or disconnect
+	if(numPlaying < 2)then
+		self:ResetRound()
+		return true
+  end
+end
+
+--- When a player crosses the finish line check if we should set a timer to prevent stalling
+function GM:PlayerFinishedRound(ply)
+  if(self.IsResetQueued)then
+    return
+  end
+
+  if(not self:CheckRoundEnd())then
+    timer.Create(STALLING_TIMER_NAME, self.RoundEndGraceConVar:GetInt(), function()
+      PrintMessage(HUD_PRINTTALK, "Players took too long to kill eachother! Ending the round now.")
+      self:ResetRound()
+    end)
+    
+    self.IsResetQueued = true
+  end
+end

--- a/gamemode/shared.lua
+++ b/gamemode/shared.lua
@@ -34,6 +34,8 @@ MsgN("Slide!")
 TEAM_RED  = 2
 TEAM_BLUE = 3
 
+GM.PlayingTeams = { TEAM_RED, TEAM_BLUE }
+
 function GM:CreateTeams()
 	team.SetUp(TEAM_RED, "Team Red", Color(255, 75, 67))
 	team.SetUp(TEAM_BLUE, "Team Blue", Color(39, 186, 255))


### PR DESCRIPTION
As discussed in issues #1, some \~creative~ solutions

This also fixes health stations which use trigger_hurt with -200 (this doesn't do anything in gmod?)

It sets the damage of those triggers to 0 and marks them with HealAmount. They are healed when the EntityTakeDamage hook notices damage == 0.

If a HealAmount of 200 is followed by a trigger_hurt of 100 damage (read from keyvalues) within END_CHECK_INTERVAL (2) seconds, that is classified as ending the map. A hook is called `SlidePlayerFinished(ply, finishedAt)`